### PR TITLE
Incrementa hello world com Spring Boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,34 @@ Certificados Livremente Emitidos, Burocratizados E Ratificados pelo DASI
 # Visão do negócio de funcionalidades
 
 [![imagem negocio](assets/Diagramas/CLEBER%20-%20Vis%C3%A3o%20Neg%C3%B3cio.png)](assets/Diagramas/CLEBER%20-%20Vis%C3%A3o%20Neg%C3%B3cio.png)
+
+
+## Organização do Projeto
+
+
+### Tecnologias
+
+#### Spring Boot
+
+O CLEBER é um projeto em [Spring Boot](https://spring.io/projects/spring-boot), escrito na linguagem de programação [Kotlin](https://kotlinlang.org/)
+
+#### Testes
+Os testes do projeto são escritos através do framework [Kotlintest](http://kotlintest.io)
+
+#### Executando Localmente
+
+Para executar localmente, é necessário executar a _task_ `bootrun`, que é fornecida pelo Spring para a ferramenta de build `gradle`.
+
+Na raíz do projeto, execute:
+
+Linux:
+```
+./gradlew bootrun
+```
+
+Windows:
+```
+gradlew.bat bootrun
+```
+
+E a aplicação principal deverá subir, permitindo acesso aos endpoints HTTP

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,15 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.30'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.31'
+
+    // Spring
+    id 'org.springframework.boot' version "2.1.5.RELEASE"
+    id 'io.spring.dependency-management' version "1.0.7.RELEASE"
+    id "org.jetbrains.kotlin.plugin.spring" version "1.3.31"
 }
 
-version '1.0-SNAPSHOT'
+group "com.dasiusp.cleber"
+version '0.0.1'
 
 sourceCompatibility = 1.8
 
@@ -12,8 +18,21 @@ repositories {
 }
 
 dependencies {
+    // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    implementation "org.jetbrains.kotlin:kotlin-reflect"
+
+    // Spring
+    implementation "org.springframework.boot:spring-boot-starter-web"
+
+    testImplementation "org.springframework.boot:spring-boot-starter-test"
+
+    // KotlinTest
+    testImplementation "io.kotlintest:kotlintest-runner-junit5:3.3.2"
+    testImplementation "io.kotlintest:kotlintest-extensions-spring:3.3.2"
+
+    // Mockk
+    testImplementation "io.mockk:mockk:1.9.3"
 }
 
 compileKotlin {
@@ -21,4 +40,8 @@ compileKotlin {
 }
 compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Jun 16 23:38:54 BRT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip

--- a/src/main/kotlin/com/dasiusp/cleber/Main.kt
+++ b/src/main/kotlin/com/dasiusp/cleber/Main.kt
@@ -1,5 +1,0 @@
-package com.dasiusp.cleber
-
-fun main() {
-    println("Ola mundo")
-}

--- a/src/main/kotlin/com/dasiusp/cleber/SpringApplication.kt
+++ b/src/main/kotlin/com/dasiusp/cleber/SpringApplication.kt
@@ -1,0 +1,11 @@
+package com.dasiusp.cleber
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class SpringApplication
+
+fun main() {
+    runApplication<SpringApplication>()
+}

--- a/src/main/kotlin/com/dasiusp/cleber/controller/HelloWorldController.kt
+++ b/src/main/kotlin/com/dasiusp/cleber/controller/HelloWorldController.kt
@@ -1,0 +1,15 @@
+package com.dasiusp.cleber.controller
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/")
+class HelloWorldController {
+
+    
+    @GetMapping("hello")
+    fun helloWorld() = "Hello, DASI!"
+    
+}

--- a/src/test/kotlin/com/dasiusp/cleber/SpringApplicationTest.kt
+++ b/src/test/kotlin/com/dasiusp/cleber/SpringApplicationTest.kt
@@ -1,0 +1,22 @@
+package com.dasiusp.cleber
+
+import io.kotlintest.specs.FunSpec
+import io.kotlintest.spring.SpringListener
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class SpringApplicationTest : FunSpec() {
+    
+    override fun listeners() = listOf(SpringListener)
+    
+    init {
+    
+        test("Context should load without any issues") {
+            // This tests doesn't require any body. The annotation @SpringBootTest
+            // Already covers that this class will be loaded with everything from the Spring context
+            // So it's not necessary to wire anything in here.
+        }
+    
+    }
+    
+}

--- a/src/test/kotlin/com/dasiusp/cleber/controller/HelloWorldControllerTest.kt
+++ b/src/test/kotlin/com/dasiusp/cleber/controller/HelloWorldControllerTest.kt
@@ -1,0 +1,16 @@
+package com.dasiusp.cleber.controller
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.FunSpec
+
+class HelloWorldControllerTest : FunSpec() {
+
+    private val helloController = HelloWorldController()
+    
+    init {
+        test("Hello World should return the correct String") {
+            helloController.helloWorld() shouldBe "Hello, DASI!"
+        }
+    }
+
+}


### PR DESCRIPTION
Este commit modifica o código atual de Hello World para fazer um endpoint HTTP que retorna hello world através do Spring Boot.

Este commit introduz duas novas tecnologias ao projeto: Spring Boot - O maior framework WEB para Java/Kotlin - e o KotlinTest - Framework para escrever testes unitários/integrados

O endpoint criado é o `/hello`, que apenas retorna uma simples mensagem, apenas para introduzir o conceito no projeto. Há um simples teste para o endpoint, para que futuros testes possam ser criados a partir de exemplos.

Este commit também inclui uma documentação de que tecnologias o projeto está utilizando, e como executá-lo localmente.

Closes #7